### PR TITLE
Python 3 compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,2 @@
-import neurons
-import util
-import rates
+from builtins import range
+__all__ = ['neurons', 'rates', 'util']

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,19 +1,21 @@
 """A quick demo of oscillation, stimulation, and background noise."""
 import numpy as np
 from fakespikes import neurons, util, rates
-import seaborn as sns; sns.__file__ # pylint
-import matplotlib.pyplot as plt; plt.ion()
+import seaborn as sns
+import matplotlib.pyplot as plt
+sns.__file__  # pylint
+plt.ion()
 
 # -- USER SETTINGS -----------------------------------------------------------
 seed = 42
-n = 50 # neuron number
-t = 5 # run 10 seconds
+n = 50  # neuron number
+t = 5  # run 10 seconds
 
-Istim = 2 # Avg rate of 'natural' stimulation
-Sstim = 0.1 * Istim # Avg st dev of natural firing
-Iosc = 10 # Avg rate of the oscillation
-f = 1 # Freq of oscillation
-Iback = 10 # Avg rate of the background noise
+Istim = 2  # Avg rate of 'natural' stimulation
+Sstim = 0.1 * Istim  # Avg st dev of natural firing
+Iosc = 10  # Avg rate of the oscillation
+f = 1  # Freq of oscillation
+Iback = 10  # Avg rate of the background noise
 
 # Timing
 dt = 0.001
@@ -36,7 +38,7 @@ spks_noise = nrns.poisson(noise)
 
 
 # Reformat and plot a raster
-spks = np.hstack([spks_osc, spks_stim, spks_noise]) # Stack 'em for plotting
+spks = np.hstack([spks_osc, spks_stim, spks_noise])  # Stack 'em for plotting
 ns, ts = util.to_spiketimes(times, spks)
 plt.plot(ts, ns, 'o')
 
@@ -55,4 +57,3 @@ plt.plot(times, spks_noise.sum(1), label='background')
 plt.legend()
 plt.xlabel("Time (s)")
 plt.ylabel("Rate")
-

--- a/neurons.py
+++ b/neurons.py
@@ -97,7 +97,7 @@ class Spikes(object):
         # http://www.cns.nyu.edu/~david/handouts/poisson.pdf
         spikes = np.zeros_like(self.unifs, np.int)
         for j in xrange(self.n):
-            mask = self.unifs[:,j] <= ((rates + biases[j]) * self.dt)
-            spikes[mask,j] = 1
+            mask = self.unifs[:, j] <= ((rates + biases[j]) * self.dt)
+            spikes[mask, j] = 1
 
         return self._refractory(spikes)

--- a/neurons.py
+++ b/neurons.py
@@ -57,7 +57,7 @@ class Spikes(object):
 
         # Create uniform sampling distributions for each neuron
         self.unifs = np.vstack(
-            [self.prng.uniform(0, 1, self.n_steps) for i in xrange(self.n)]
+            [self.prng.uniform(0, 1, self.n_steps) for i in range(self.n)]
         ).transpose()
 
     def _constraints(self, drive):
@@ -71,9 +71,9 @@ class Spikes(object):
 
         # If it spiked at t, delete spikes
         # in the refractory window
-        for t in xrange(spks.shape[0]):
+        for t in range(spks.shape[0]):
             mask = spks[t, :]
-            for t_plus in xrange(lw):
+            for t_plus in range(lw):
                 spks[t_plus, :][mask] = 0
 
         return spks
@@ -96,7 +96,7 @@ class Spikes(object):
         # Poisson method taken from
         # http://www.cns.nyu.edu/~david/handouts/poisson.pdf
         spikes = np.zeros_like(self.unifs, np.int)
-        for j in xrange(self.n):
+        for j in range(self.n):
             mask = self.unifs[:, j] <= ((rates + biases[j]) * self.dt)
             spikes[mask, j] = 1
 

--- a/rates.py
+++ b/rates.py
@@ -31,7 +31,5 @@ def stim(times, d, scale, seed=None):
 
 def constant(times, d):
     """Constant drive, d"""
-    
+
     return np.repeat(d, len(times))
-
-

--- a/util.py
+++ b/util.py
@@ -12,7 +12,7 @@ def to_spiketimes(times, spikes):
     ns, ts = [], []
     for i in xrange(n_steps):
         for j in xrange(n):
-            if spikes[i,j] == 1:
+            if spikes[i, j] == 1:
                 ns.append(j)  # save neuron and
                 ts.append(times[i])  # look up dt time
 
@@ -54,4 +54,3 @@ def isi(d_sp):
         d_isi[k] = np.array(intervals)
 
     return d_isi
-

--- a/util.py
+++ b/util.py
@@ -10,8 +10,8 @@ def to_spiketimes(times, spikes):
     n = spikes.shape[1]
 
     ns, ts = [], []
-    for i in xrange(n_steps):
-        for j in xrange(n):
+    for i in range(n_steps):
+        for j in range(n):
             if spikes[i, j] == 1:
                 ns.append(j)  # save neuron and
                 ts.append(times[i])  # look up dt time


### PR DESCRIPTION
Hi all,

This PR just has a few changes which allow the script to work with both Python 2.7.x and Python 3.4.3. I tested it with both python called from terminal and IPython 4.0.0 on Ubuntu 15.04 64-bit.

The changes are pretty simple.

1. PEP8 compliant spacing and module importing - just something my editor does automatically, no change in function.

2. As it turns out, Python 2 and 3 have some pretty funky differences when it comes to making modules and packages. In particular, while the __init__.py given is fine for Python 2, it messes with Python 3 because the latter apparently has problems when the working directory is both in the PATH or PYTHONPATH variables and tries to import modules on its own. I'm still hazy on the specifics of why this happens, but it can be fixed by simply making __init__.py blank, because all the script files imoprt the modules anyway. Instead of doing that, I just replaced __init__.py with a single like so `frome fakespikes import *` works, if the user wants to do something like that with the scripts.

I think that's all the changes. Let me know if something else is amiss.